### PR TITLE
refactor: improve caret positioning logic in TextView

### DIFF
--- a/Lexical/TextView/TextView.swift
+++ b/Lexical/TextView/TextView.swift
@@ -122,15 +122,24 @@ protocol LexicalTextViewDelegate: NSObjectProtocol {
     }
 
     override public func caretRect(for position: UITextPosition) -> CGRect {
-        var rect = super.caretRect(for: position)
-        guard let font = self.font else { return rect }
+        var caretRect = super.caretRect(for: position)
+        let characterIndex = offset(from: beginningOfDocument, to: position)
 
-        let targetHeight = font.lineHeight
+        guard layoutManager.isValidGlyphIndex(characterIndex) else {
+            return caretRect
+        }
 
-        rect.origin.y += (rect.height - targetHeight) / 2
-        rect.size.height = targetHeight
+        let glyphIndex = layoutManager.glyphIndexForCharacter(at: characterIndex)
+        let usedLineFragment = layoutManager.lineFragmentUsedRect(forGlyphAt: glyphIndex, effectiveRange: nil)
 
-        return rect
+        guard !usedLineFragment.isEmpty else {
+            return caretRect
+        }
+
+        caretRect.origin.y = usedLineFragment.origin.y + textContainerInset.top
+        caretRect.size.height = usedLineFragment.size.height
+
+        return caretRect
     }
 
     override public var inputDelegate: UITextInputDelegate? {


### PR DESCRIPTION
- Updated the `caretRect(for:)` method to enhance caret positioning based on the line fragment used by the layout manager.
- Ensured that the caret's height and vertical position are adjusted according to the text container's inset and the line fragment's dimensions.
- This change aims to provide a more accurate visual representation of the caret in the text view, improving the overall user experience.