### PR TITLE
fix: enable vertical scroll indicator in TextView

### DIFF
--- a/Lexical/LexicalView/LexicalView.swift
+++ b/Lexical/LexicalView/LexicalView.swift
@@ -63,7 +63,7 @@ public extension LexicalViewDelegate {
     titlePlaceholderText: LexicalPlaceholderText? = nil
   ) {
     self.textView = TextView(editorConfig: editorConfig, featureFlags: featureFlags)
-    self.textView.showsVerticalScrollIndicator = false
+    self.textView.showsVerticalScrollIndicator = true
     self.textView.clipsToBounds = true
     self.textView.accessibilityTraits = .staticText
     self.placeholderText = placeholderText


### PR DESCRIPTION
- Changed the `showsVerticalScrollIndicator` property of the `TextView` from `false` to `true`.
- This update enhances the user experience by providing a visual cue for scrolling, making it easier for users to navigate through longer text content.